### PR TITLE
18721: Seitenumbruch wird nur eingefügt, wenn keine andere h2 Überschriften …

### DIFF
--- a/AzureDevOps.WikiPDFExport/MarkdownConverter.cs
+++ b/AzureDevOps.WikiPDFExport/MarkdownConverter.cs
@@ -82,6 +82,8 @@ namespace azuredevops_export_wiki
                 files.Insert(_options.GlobalTOCPosition, tocMarkdownFile);
             }
 
+            bool hasH2NoAsTopLevelHeadline = false;
+
             for (var i = 0; i < files.Count; i++)
             {
                 var mf = files[i];
@@ -89,7 +91,10 @@ namespace azuredevops_export_wiki
 
                 Log($"{file.Name}", LogLevel.Information, 1);
 
-                var md = AzureDevopsToMarkdownConverter.ConvertAzureDevopsToStandardMarkdown(mf.Content);
+                var (mdContext, newHasH2NoAsTopLevelHeadline) = AzureDevopsToMarkdownConverter.ConvertAzureDevopsToStandardMarkdown(mf.Content, hasH2NoAsTopLevelHeadline);
+
+                hasH2NoAsTopLevelHeadline = newHasH2NoAsTopLevelHeadline;
+                var md = mdContext;
 
                 if (string.IsNullOrEmpty(md))
                 {


### PR DESCRIPTION
Es wird eine Überschrift der ersten Ebene auf einer neuen Seite angezeigt, wenn vor ihr keine Überschrift der gleichen Ebene ist.